### PR TITLE
Lowercase the `logrus` import

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Graylog Hook for [Logrus](https://github.com/Sirupsen/logrus) <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:" />&nbsp;[![Build Status](https://travis-ci.org/gemnasium/logrus-graylog-hook.svg?branch=master)](https://travis-ci.org/gemnasium/logrus-graylog-hook)&nbsp;[![godoc reference](https://godoc.org/github.com/gemnasium/logrus-graylog-hook?status.svg)](https://godoc.org/gopkg.in/gemnasium/logrus-graylog-hook.v1)
+# Graylog Hook for [Logrus](https://github.com/sirupsen/logrus) <img src="http://i.imgur.com/hTeVwmJ.png" width="40" height="40" alt=":walrus:" class="emoji" title=":walrus:" />&nbsp;[![Build Status](https://travis-ci.org/gemnasium/logrus-graylog-hook.svg?branch=master)](https://travis-ci.org/gemnasium/logrus-graylog-hook)&nbsp;[![godoc reference](https://godoc.org/github.com/gemnasium/logrus-graylog-hook?status.svg)](https://godoc.org/gopkg.in/gemnasium/logrus-graylog-hook.v1)
 
 Use this hook to send your logs to [Graylog](http://graylog2.org) server over UDP.
 The hook is non-blocking: even if UDP is used to send messages, the extra work
@@ -17,7 +17,7 @@ The hook must be configured with:
 ```go
 import (
     "log/syslog"
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "gopkg.in/gemnasium/logrus-graylog-hook.v1"
     )
 
@@ -34,7 +34,7 @@ func main() {
 ```go
 import (
     "log/syslog"
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
     "gopkg.in/gemnasium/logrus-graylog-hook.v1"
     )
 

--- a/graylog_hook.go
+++ b/graylog_hook.go
@@ -10,7 +10,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/alfatraining/go-gelf/gelf"
 )
 

--- a/graylog_hook_test.go
+++ b/graylog_hook_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/Sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"github.com/alfatraining/go-gelf/gelf"
 )
 


### PR DESCRIPTION
The gist: the repository changed from `github.com/Sirupsen/logrus` to `github.com/sirupsen/logrus`. For a Glide workaround see https://github.com/sirupsen/logrus/issues/553#issuecomment-306591437 and the following comments (namely, busting its cache).

Test suite is still green.